### PR TITLE
Remove now unused function cdc_shell_write_string() in usb_cdc.c

### DIFF
--- a/usb_cdc.c
+++ b/usb_cdc.c
@@ -433,10 +433,6 @@ void cdc_shell_write(const void *buf, size_t count) {
     }
 }
 
-void cdc_shell_write_string(const char *buf) {
-    cdc_shell_write(buf, strlen(buf));
-}
-
 /* USB USART TX Functions */
 
 static void usb_cdc_port_start_tx(int port) {


### PR DESCRIPTION
Actually forgot to remove cdc_shell_write_string() from usb_cdc.c.