### PR TITLE
Announce Correct ACM Capabilities in USB Descriptors

### DIFF
--- a/usb_cdc.h
+++ b/usb_cdc.h
@@ -37,6 +37,13 @@ typedef enum {
     usb_descriptor_subtype_cdc_country         = 0x07,
 } __attribute__ ((packed)) usb_descriptor_subtype_cdc_t;
 
+#define USB_CDC_ACM_CAPABILITY_COMM_FEATURE         0x01
+#define USB_CDC_ACM_CAPABILITY_LINE_CODING          0x02
+#define USB_CDC_ACM_CAPABILITY_SEND_BREAK           0x04
+#define USB_CDC_ACM_CAPABILITY_NETWORK_CONNECTION   0x08
+
+#define USB_CDC_ACM_CAPABILITIES (USB_CDC_ACM_CAPABILITY_LINE_CODING)
+
 /* USB CDC Header Functional Descriptor */
 
 typedef struct  {

--- a/usb_descriptors.c
+++ b/usb_descriptors.c
@@ -145,7 +145,7 @@ const usb_device_configuration_descriptor_t usb_configuration_descriptor = {
         .bFunctionLength        = sizeof(usb_configuration_descriptor.cdc_acm_0),
         .bDescriptorType        = usb_descriptor_type_cs_interface,
         .bDescriptorSubType     = usb_descriptor_subtype_cdc_acm,
-        .bmCapabilities         = 0,
+        .bmCapabilities         = USB_CDC_ACM_CAPABILITIES,
     },
     .cdc_union_0 = {
         .bFunctionLength        = sizeof(usb_configuration_descriptor.cdc_union_0),
@@ -227,7 +227,7 @@ const usb_device_configuration_descriptor_t usb_configuration_descriptor = {
         .bFunctionLength        = sizeof(usb_configuration_descriptor.cdc_acm_1),
         .bDescriptorType        = usb_descriptor_type_cs_interface,
         .bDescriptorSubType     = usb_descriptor_subtype_cdc_acm,
-        .bmCapabilities         = 0,
+        .bmCapabilities         = USB_CDC_ACM_CAPABILITIES,
     },
     .cdc_union_1 = {
         .bFunctionLength        = sizeof(usb_configuration_descriptor.cdc_union_1),
@@ -309,7 +309,7 @@ const usb_device_configuration_descriptor_t usb_configuration_descriptor = {
         .bFunctionLength        = sizeof(usb_configuration_descriptor.cdc_acm_2),
         .bDescriptorType        = usb_descriptor_type_cs_interface,
         .bDescriptorSubType     = usb_descriptor_subtype_cdc_acm,
-        .bmCapabilities         = 0,
+        .bmCapabilities         = USB_CDC_ACM_CAPABILITIES,
     },
     .cdc_union_2 = {
         .bFunctionLength        = sizeof(usb_configuration_descriptor.cdc_union_2),


### PR DESCRIPTION
Currently ACM functional descriptors have bmCapabilities set to 0, which is not correct because the firmware supports Set_Line_Condinf, Set_Control_Line_State, Get_Line_Coding and Serial_State notification. bmCapabilities should be set to 0x02 reflect this.