### PR TITLE
Fix build failure due to "multiple definition" errors

### DIFF
--- a/usb_descriptors.h
+++ b/usb_descriptors.h
@@ -28,7 +28,7 @@ typedef enum {
     usb_string_index_last,
 } __attribute__ ((packed)) usb_string_index_t;
 
-const usb_string_descriptor_t *usb_string_descriptors[usb_string_index_last];
+extern const usb_string_descriptor_t *usb_string_descriptors[usb_string_index_last];
 
 /* Endpoints */
 
@@ -55,7 +55,7 @@ enum {
 
 /* Device Descriptor */
 
-const usb_device_descriptor_t usb_device_descriptor;
+extern const usb_device_descriptor_t usb_device_descriptor;
 
 /* Configuration Descriptor */
 
@@ -93,6 +93,6 @@ typedef struct {
     usb_endpoint_descriptor_t           data_eptx_2;
 } __attribute__((packed)) usb_device_configuration_descriptor_t;
 
-const usb_device_configuration_descriptor_t usb_configuration_descriptor;
+extern const usb_device_configuration_descriptor_t usb_configuration_descriptor;
 
 #endif /* USB_DESCRIPTORS_H */


### PR DESCRIPTION
The USB descriptor variables were effectively being declared twice--once in `usb_descriptors.c` and once in `usb_core.c`--because both files included `usb_descriptors.h`, where those variables were originally declared without the "extern" keyword. Because of this, GCC refused to link the object files. After declaring the variables as "extern", the build finishes without issue.

Here's an example of the issue this PR fixes:

```
/usr/lib/gcc/arm-none-eabi/10.2.0/../../../../arm-none-eabi/bin/ld: build/usb_descriptors.o:/src/bluepill-serial-monster/usb_descriptors.h:96: multiple definition of `usb_configuration_descriptor'; build/usb_core.o:/src/bluepill-serial-monster/usb_descriptors.h:96: first defined here
/usr/lib/gcc/arm-none-eabi/10.2.0/../../../../arm-none-eabi/bin/ld: build/usb_descriptors.o:/src/bluepill-serial-monster/usb_descriptors.h:58: multiple definition of `usb_device_descriptor'; build/usb_core.o:/src/bluepill-serial-monster/usb_descriptors.h:58: first defined here
/usr/lib/gcc/arm-none-eabi/10.2.0/../../../../arm-none-eabi/bin/ld: build/usb_descriptors.o:/src/bluepill-serial-monster/usb_descriptors.h:31: multiple definition of `usb_string_descriptors'; build/usb_core.o:/src/bluepill-serial-monster/usb_descriptors.h:31: first defined here
/usr/lib/gcc/arm-none-eabi/10.2.0/../../../../arm-none-eabi/bin/ld: build/usb_io.o:/src/bluepill-serial-monster/usb_descriptors.h:96: multiple definition of `usb_configuration_descriptor'; build/usb_core.o:/src/bluepill-serial-monster/usb_descriptors.h:96: first defined here
/usr/lib/gcc/arm-none-eabi/10.2.0/../../../../arm-none-eabi/bin/ld: build/usb_io.o:/src/bluepill-serial-monster/usb_descriptors.h:58: multiple definition of `usb_device_descriptor'; build/usb_core.o:/src/bluepill-serial-monster/usb_descriptors.h:58: first defined here
/usr/lib/gcc/arm-none-eabi/10.2.0/../../../../arm-none-eabi/bin/ld: build/usb_io.o:/src/bluepill-serial-monster/usb_descriptors.h:31: multiple definition of `usb_string_descriptors'; build/usb_core.o:/src/bluepill-serial-monster/usb_descriptors.h:31: first defined here
/usr/lib/gcc/arm-none-eabi/10.2.0/../../../../arm-none-eabi/bin/ld: build/usb_cdc.o:/src/bluepill-serial-monster/usb_descriptors.h:96: multiple definition of `usb_configuration_descriptor'; build/usb_core.o:/src/bluepill-serial-monster/usb_descriptors.h:96: first defined here
/usr/lib/gcc/arm-none-eabi/10.2.0/../../../../arm-none-eabi/bin/ld: build/usb_cdc.o:/src/bluepill-serial-monster/usb_descriptors.h:58: multiple definition of `usb_device_descriptor'; build/usb_core.o:/src/bluepill-serial-monster/usb_descriptors.h:58: first defined here
/usr/lib/gcc/arm-none-eabi/10.2.0/../../../../arm-none-eabi/bin/ld: build/usb_cdc.o:/src/bluepill-serial-monster/usb_descriptors.h:31: multiple definition of `usb_string_descriptors'; build/usb_core.o:/src/bluepill-serial-monster/usb_descriptors.h:31: first defined here
collect2: error: ld returned 1 exit status
make: *** [Makefile:52: bluepill-serial-monster.elf] Error 1
```