### PR TITLE
Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,10 +43,10 @@ STARTUP		+= $(STM32_STARTUP:%.s=$(BUILD_DIR)/%.o)
 all: $(TARGET).hex $(TARGET).bin size
 
 $(TARGET).bin: $(TARGET).elf
-	$(OBJCOPY) -Obinary $(TARGET).elf $(TARGET).bin
+	$(OBJCOPY) -Obinary $< $@
 
 $(TARGET).hex: $(TARGET).elf
-	$(OBJCOPY) -Oihex $(TARGET).elf $(TARGET).hex
+	$(OBJCOPY) -Oihex $< $@
 
 $(TARGET).elf: $(OBJS) $(STARTUP)
 	$(CC) $(LDFLAGS) $^ -o $@
@@ -67,12 +67,12 @@ cppcheck: $(SRCS)
 	$(CPPCHECK) $(CHKFLAGS) $(STM32_INCLUDES) $(DEFINES) --output-file=$(CHKREPORT) $^
 
 .PHONY: flash
-flash: all
-	$(STFLASH) --format ihex write $(TARGET).hex
+flash: $(TARGET).hex
+	$(STFLASH) --format ihex write $<
 
 .PHONY: size
-size:
-	$(SIZE) $(TARGET).elf
+size: $(TARGET).elf
+	$(SIZE) $<
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,10 @@ SRCS	= main.c system_clock.c system_interrupts.c status_led.c usb_core.c usb_des
 	usb_io.c usb_uid.c usb_panic.c usb_cdc.c cdc_shell.c gpio.c device_config.c
 
 # Toolchain & Utils
-CC		= arm-none-eabi-gcc
-OBJCOPY		= arm-none-eabi-objcopy
-SIZE		= arm-none-eabi-size
+CROSS_COMPILE	?= arm-none-eabi-
+CC		= $(CROSS_COMPILE)gcc
+OBJCOPY		= $(CROSS_COMPILE)objcopy
+SIZE		= $(CROSS_COMPILE)size
 STFLASH		= st-flash
 STUTIL		= st-util
 CPPCHECK	= cppcheck


### PR DESCRIPTION
These are some small improvements for the Makefile.

The first commit fixes the dependencies for the "flash" and "size" targets. This is important since when running a parallel build (with, say, `make -j4`), if `$(TARGET).elf` isn't built by the time `$(SIZE) $(TARGET).elf` is run, the entire build will fail with the following error:

```
arm-none-eabi-size bluepill-serial-monster.elf
arm-none-eabi-size: 'bluepill-serial-monster.elf': No such file
make: *** [Makefile:75: size] Error 1
make: *** Waiting for unfinished jobs....
```

After making that small change, the build never fails, no matter how many threads are used.

The second commit is more a matter of convenience, and allows you to specify your toolchain with the `CROSS_COMPILE` environment variable. The name is somewhat arbitrary--I just used the same name and semantics that the [ARM Trusted Firmware-A](https://github.com/ARM-software/arm-trusted-firmware) project uses for specifying a toolchain.