### PR TITLE
Use DMA polling instead of TC/HT and USART IDLE interrupts for RX buffer updates

### DIFF
--- a/usb_cdc.c
+++ b/usb_cdc.c
@@ -753,7 +753,7 @@ void usb_cdc_poll() {
     for (int port = 0; port < (USB_CDC_NUM_PORTS); port++) {
         usb_cdc_state_t *cdc_state = &usb_cdc_states[port];
         circ_buf_t *tx_buf = &cdc_state->tx_buf;
-        if ((port != USB_CDC_CONFIG_PORT) && (usb_cdc_config_mode == 0)) {
+        if ((port != USB_CDC_CONFIG_PORT) || (usb_cdc_config_mode == 0)) {
             usb_cdc_sync_rx_buffer(port);
         }
         usb_cdc_notify_port_state_change(port);

--- a/usb_cdc.c
+++ b/usb_cdc.c
@@ -753,7 +753,9 @@ void usb_cdc_poll() {
     for (int port = 0; port < (USB_CDC_NUM_PORTS); port++) {
         usb_cdc_state_t *cdc_state = &usb_cdc_states[port];
         circ_buf_t *tx_buf = &cdc_state->tx_buf;
-        usb_cdc_sync_rx_buffer(port);
+        if ((port != USB_CDC_CONFIG_PORT) && (usb_cdc_config_mode == 0)) {
+            usb_cdc_sync_rx_buffer(port);
+        }
         usb_cdc_notify_port_state_change(port);
         usb_cdc_port_send_rx_usb(port);
         if (cdc_state->line_state_change_ready) {


### PR DESCRIPTION
It seems that using DMA TC/HC interrupts in conjunction with the USART IDLE interrupt for updating RX buffers head positions is a wrong strategy in the case of a USB to UART bridge.

Consider the following scenario: a low-speed device (say 2400, 9600 baud) connected to UART sends a steady stream of bytes. There are no gaps in transmission, so that the USART IDLE interrupt never triggers. On the other hand, since the RX buffers on bluepill-serial-monster are relatively large, the firmware will not send the content of the RX buffer to the host until DMA TC/HC triggers. While it does not lead to data loss, it creates a noticeable delay which can be critical for applications that rely on RX timing.

On the other hand, the firmware can only send the data to the host in the USB polling loop, so it makes perfect sense to update circular buffers there as well.

As a side effect, this change introduces a slight delay in the RTS signal handling. It looks like it should not be a problem, however this requires some additional testing.