### PR TITLE
Feature proposal: Gpio control

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # General Target Settings
 TARGET	= bluepill-serial-monster
 SRCS	= main.c system_clock.c system_interrupts.c status_led.c usb_core.c usb_descriptors.c\
-	usb_io.c usb_uid.c usb_panic.c usb_cdc.c cdc_shell.c gpio.c device_config.c
+	usb_io.c usb_uid.c usb_panic.c usb_cdc.c cdc_shell.c gpio.c device_config.c gpio_control.c
 
 # Toolchain & Utils
 CROSS_COMPILE	?= arm-none-eabi-
@@ -28,7 +28,7 @@ WARNINGS	= -Wall
 OPTIMIZATION	= -O3
 DEBUG		= -ggdb
 
-CFLAGS		= $(DEFINES) $(STM32_INCLUDES) $(CPUFLAGS) $(WARNINGS) $(OPTIMIZATION) $(DEBUG) 
+CFLAGS		= $(DEFINES) $(STM32_INCLUDES) $(CPUFLAGS) $(WARNINGS) $(OPTIMIZATION) $(DEBUG)
 LDFLAGS		= $(CPUFLAGS) -T$(STM32_LDSCRIPT) --specs=nosys.specs --specs=nano.specs
 DEPFLAGS	= -MT $@ -MMD -MP -MF $(BUILD_DIR)/$*.d
 

--- a/cdc_shell.c
+++ b/cdc_shell.c
@@ -429,7 +429,7 @@ static void cdc_shell_gpio_print_config(int portnum, int pinnum) {
     const char *outtype = _cdc_uart_output_types[gc_pin->output];
     const char *pull = _cdc_uart_pull_types[gc_pin->pull];
     const char *val = gc_pin->val ? "1" : "0";
-    snprintf(buf, sizeof(buf), "%c%d: %s %s %s %s\r\n", portnum == 0 ? 'A' : 'B', pinnum, dir, outtype, pull, val);
+    snprintf(buf, sizeof(buf), "%c%d\t- %s %s %s %s\r\n", portnum == 0 ? 'A' : 'B', pinnum, dir, outtype, pull, val);
     cdc_shell_write_string(buf);
 }
 
@@ -459,32 +459,37 @@ static void cdc_shell_gpio_cmd_config(int argc, char *argv[]) {
         cdc_shell_write_string("Bad gpio.\r\n");
         return;
     }
-    argc--; argv++;
+    argc--;
+    argv++;
     gpio_control_pin_t *gc_pin = &device_config_get()->gpio_control.ports[portnum].pins[pinnum];
 
     gpio_control_pin_t new_pin = *gc_pin;
     while (argc >= 2) {
         if (strcmp(*argv, "dir") == 0) {
-            argc--; argv++;
+            argc--;
+            argv++;
             gpio_dir_t dir = _gpio_dir_by_name(*argv);
             if (dir != gpio_dir_unknown) {
                 new_pin.dir = dir;
             }
         } else if (strcmp(*argv, "output") == 0) {
-            argc--; argv++;
+            argc--;
+            argv++;
             gpio_output_t output = _cdc_uart_output_type_by_name(*argv);
             if (output != gpio_output_unknown) {
                 new_pin.output = output;
             }
         } else if (strcmp(*argv, "val") == 0) {
-            argc--; argv++;
+            argc--;
+            argv++;
             if ((*argv)[0] == '1') {
                 new_pin.val = 1;
             } else {
                 new_pin.val = 0;
             }
         } else if (strcmp(*argv, "pull") == 0) {
-            argc--; argv++;
+            argc--;
+            argv++;
             gpio_pull_t pull = _cdc_uart_pull_type_by_name(*argv);
             if (pull != gpio_pull_unknown) {
                 new_pin.pull = pull;
@@ -495,14 +500,14 @@ static void cdc_shell_gpio_cmd_config(int argc, char *argv[]) {
             cdc_shell_write_string(buf);
             return;
         }
-        argc--; argv++;
+        argc--;
+        argv++;
     }
     if (memcmp(&new_pin, gc_pin, sizeof(gpio_control_pin_t)) != 0) {
         *gc_pin = new_pin;
         gpio_control_reconfigure_pin(portnum, pinnum);
     }
     cdc_shell_gpio_print_config(portnum, pinnum);
-
 }
 
 static void cdc_shell_gpio_cmd_read(int argc, char *argv[]) {
@@ -530,7 +535,7 @@ static void cdc_shell_gpio_cmd_read(int argc, char *argv[]) {
 
 static void cdc_shell_gpio_cmd_write(int argc, char *argv[]) {
     int portnum, pinnum;
-    if (argc < 2) {
+    if (argc != 2) {
         cdc_shell_write_string("Bad arguments.\r\n");
         return;
     }
@@ -538,8 +543,7 @@ static void cdc_shell_gpio_cmd_write(int argc, char *argv[]) {
         cdc_shell_write_string("Bad gpio.\r\n");
         return;
     }
-    argc--; argv++;
-    if ((*argv)[0] == '0') {
+    if (argv[1][0] == '0') {
         gpio_control_write(portnum, pinnum, 0);
     } else {
         gpio_control_write(portnum, pinnum, 1);
@@ -645,7 +649,7 @@ static const cdc_shell_cmd_t cdc_shell_commands[] = {
                           "  val\t[0|1] for output only\r\n"
                           "  pull\t\t[floating|up|down] for input only\r\n"
                           "Use \"gpio read all|pn pn+1 pn+2 ...\" to read state of pins\r\n"
-                          "Use \"gpio write pn 0|1 pn+1 [0|1] ...\" to set values of outputs\r\n"
+                          "Use \"gpio write pn 0|1\" to set state of an output\r\n"
     },
     { 0 }
 };

--- a/device_config.c
+++ b/device_config.c
@@ -1,6 +1,6 @@
 /*
- * MIT License 
- * 
+ * MIT License
+ *
  * Copyright (c) 2020 Kirill Kotyagin
  */
 
@@ -23,7 +23,7 @@ static const device_config_t default_device_config = {
         .port_config = {
             /*  Port 0 */
             {
-                .pins = 
+                .pins =
                 {
                     /*  rx */ { .port = GPIOA, .pin = 10, .dir = gpio_dir_input,  .pull = gpio_pull_up, .polarity = gpio_polarity_high },
                     /*  tx */ { .port = GPIOA, .pin =  9, .dir = gpio_dir_output, .speed = gpio_speed_medium, .func = gpio_func_alternate, .output = gpio_output_pp, .polarity = gpio_polarity_high },
@@ -38,7 +38,7 @@ static const device_config_t default_device_config = {
             },
             /*  Port 1 */
             {
-                .pins = 
+                .pins =
                 {
                     /*  rx */ { .port = GPIOA, .pin =  3, .dir = gpio_dir_input,  .pull = gpio_pull_up, .polarity = gpio_polarity_high },
                     /*  tx */ { .port = GPIOA, .pin =  2, .dir = gpio_dir_output, .speed = gpio_speed_medium, .func = gpio_func_alternate, .output = gpio_output_pp, .polarity = gpio_polarity_high },
@@ -53,7 +53,7 @@ static const device_config_t default_device_config = {
             },
             /*  Port 2 */
             {
-                .pins = 
+                .pins =
                 {
                     /*  rx */ { .port = GPIOB, .pin = 11, .dir = gpio_dir_input,  .pull = gpio_pull_up, .polarity = gpio_polarity_high },
                     /*  tx */ { .port = GPIOB, .pin = 10, .dir = gpio_dir_output, .speed = gpio_speed_medium, .func = gpio_func_alternate, .output = gpio_output_pp, .polarity = gpio_polarity_high  },
@@ -67,7 +67,53 @@ static const device_config_t default_device_config = {
                 }
             },
         }
-    }
+    },
+    .gpio_control = {
+        .ports = {
+            /*  GPIOA */
+            {
+                .pins = {
+                    /* 0  */ {.uart_port = 1, .uart_pin = cdc_pin_cts},
+                    /* 1  */ {.uart_port = 1, .uart_pin = cdc_pin_rts},
+                    /* 2  */ {.uart_port = 1, .uart_pin = cdc_pin_tx},
+                    /* 3  */ {.uart_port = 1, .uart_pin = cdc_pin_rx},
+                    /* 4  */ {.uart_port = 0, .uart_pin = cdc_pin_dtr},
+                    /* 5  */ {.uart_port = 1, .uart_pin = cdc_pin_dtr},
+                    /* 6  */ {.uart_port = 2, .uart_pin = cdc_pin_dtr},
+                    /* 7  */ {.uart_port = 2, .uart_pin = cdc_pin_txa},
+                    /* 8  */ {.uart_port = 2, .uart_pin = cdc_pin_ri},
+                    /* 9  */ {.uart_port = 0, .uart_pin = cdc_pin_tx},
+                    /* 10 */ {.uart_port = 0, .uart_pin = cdc_pin_rx},
+                    /* 11 */ {.dir = gpio_dir_unknown}, // USB D-
+                    /* 12 */ {.dir = gpio_dir_unknown}, // USB D+
+                    /* 13 */ {.dir = gpio_dir_unknown}, // SWDIO
+                    /* 14 */ {.dir = gpio_dir_unknown}, // SWCLK
+                    /* 15 */ {.uart_port = 0, .uart_pin = cdc_pin_rts},
+                },
+            },
+            {
+            /*  GPIOB */
+                .pins = {
+                    /* 0  */ {.uart_port = 0, .uart_pin = cdc_pin_txa},
+                    /* 1  */ {.uart_port = 1, .uart_pin = cdc_pin_txa},
+                    /* 2  */ {.dir = gpio_dir_unknown}, // BOOT1, not on side connector, but could be enabled
+                    /* 3  */ {.uart_port = 0, .uart_pin = cdc_pin_ri},
+                    /* 4  */ {.uart_port = 1, .uart_pin = cdc_pin_dsr},
+                    /* 5  */ {.dir = gpio_dir_unknown}, // config pin
+                    /* 6  */ {.uart_port = 2, .uart_pin = cdc_pin_dsr},
+                    /* 7  */ {.uart_port = 0, .uart_pin = cdc_pin_dsr},
+                    /* 8  */ {.uart_port = 1, .uart_pin = cdc_pin_dcd},
+                    /* 9  */ {.uart_port = 2, .uart_pin = cdc_pin_dcd},
+                    /* 10 */ {.uart_port = 2, .uart_pin = cdc_pin_tx},
+                    /* 11 */ {.uart_port = 2, .uart_pin = cdc_pin_rx},
+                    /* 12 */ {.uart_port = 1, .uart_pin = cdc_pin_ri},
+                    /* 13 */ {.uart_port = 2, .uart_pin = cdc_pin_cts},
+                    /* 14 */ {.uart_port = 2, .uart_pin = cdc_pin_rts},
+                    /* 15 */ {.uart_port = 0, .uart_pin = cdc_pin_dcd},
+                },
+            }
+        },
+    },
 };
 
 static device_config_t current_device_config;

--- a/device_config.c
+++ b/device_config.c
@@ -119,6 +119,10 @@ device_config_t *device_config_get() {
     return &current_device_config;
 }
 
+const device_config_t *device_config_get_default() {
+    return &default_device_config;
+}
+
 void device_config_save() {
     uint16_t *last_config_magic = 0;
     uint8_t *config_page = (uint8_t*)DEVICE_CONFIG_BASE_ADDR;

--- a/device_config.h
+++ b/device_config.h
@@ -1,6 +1,6 @@
 /*
- * MIT License 
- * 
+ * MIT License
+ *
  * Copyright (c) 2020 Kirill Kotyagin
  */
 
@@ -10,13 +10,15 @@
 #include <stdint.h>
 #include "gpio.h"
 #include "cdc_config.h"
+#include "gpio_control.h"
 
 typedef struct {
-    uint32_t        magic;
-    gpio_pin_t      status_led_pin;
-    gpio_pin_t      config_pin;
-    cdc_config_t    cdc_config;
-    uint32_t        crc; /* should be the last member of the struct */
+    uint32_t              magic;
+    gpio_pin_t            status_led_pin;
+    gpio_pin_t            config_pin;
+    cdc_config_t          cdc_config;
+    gpio_control_config_t gpio_control;
+    uint32_t              crc; /* should be the last member of the struct */
 } __attribute__ ((packed, aligned(4))) device_config_t;
 
 void device_config_init();

--- a/device_config.h
+++ b/device_config.h
@@ -21,6 +21,7 @@ typedef struct {
 
 void device_config_init();
 device_config_t *device_config_get();
+const device_config_t *device_config_get_default();
 
 void device_config_save();
 void device_config_reset();

--- a/gpio_control.c
+++ b/gpio_control.c
@@ -48,3 +48,21 @@ void gpio_control_reconfigure_pin(GPIO_TypeDef *gpio_port, uint8_t gpio_pin_num)
     _pin_control_cfg_prepare(&p, uart_pin, gpio_pin_cfg);
     gpio_pin_init(&p);
 }
+
+gpio_pin_t *gpio_control_find_uart_pincfg(gpio_control_pin_t *gc_pin) {
+    // if (gc_pin->dir == gpio_dir_unknown) return NULL;
+    if (gc_pin->uart_port < 0) return NULL;
+    return &device_config_get()->cdc_config.port_config[gc_pin->uart_port].pins[gc_pin->uart_pin];
+}
+
+int gpio_control_read(int portnum, int pinnum) {
+    if (portnum >= GPIO_CONGROL_NUM_PORTS) return 0;
+    if (pinnum >= GPIO_CONTROL_PINS_PER_PORT) return 0;
+    gpio_control_pin_t *gc_pin = &device_config_get()->gpio_control.ports[portnum].pins[pinnum];
+    gpio_pin_t *u_pin = gpio_control_find_uart_pincfg(gc_pin);
+    if (u_pin == NULL) return 0;
+
+    gpio_pin_t p;
+    _pin_control_cfg_prepare(&p, u_pin, gc_pin);
+    return gpio_pin_get(&p);
+}

--- a/gpio_control.c
+++ b/gpio_control.c
@@ -13,28 +13,33 @@ static inline int8_t _port_idx_by_address(GPIO_TypeDef *port) {
     return -1;
 }
 
-static inline void _pin_control_cfg_prepare(gpio_pin_t *pin, const gpio_pin_t *uart_pin, const gpio_control_pin_t *gpio_pin) {
-    // memset(pin, 0, sizeof(*pin));
+static inline GPIO_TypeDef *_port_address_by_idx(int portnum) {
+    if (portnum == 0) return GPIOA;
+    if (portnum == 1) return GPIOB;
+    return NULL;
+}
 
-    pin->port = uart_pin->port;
-    pin->pin = uart_pin->pin;
-    pin->dir = gpio_pin->dir;
+static inline void _pin_control_cfg_prepare(gpio_pin_t *pin, int portnum, int pinnum) {
+    const gpio_control_pin_t *gc_pin = &device_config_get()->gpio_control.ports[portnum].pins[pinnum];
+
+    pin->port = _port_address_by_idx(portnum);
+    pin->pin = pinnum;
+    pin->dir = gc_pin->dir;
     pin->func = gpio_func_general;
     // if (pin->dir == gpio_dir_output) {
-        pin->output = gpio_pin->output;
+        pin->output = gc_pin->output;
     // } else { // output
-        pin->pull = gpio_pin->pull;
+        pin->pull = gc_pin->pull;
     // }
     pin->polarity = gpio_polarity_high;
     pin->speed = gpio_speed_low;
 }
 
-void gpio_control_reconfigure_pin(GPIO_TypeDef *gpio_port, uint8_t gpio_pin_num) {
-    if (gpio_pin_num >= GPIO_CONTROL_PINS_PER_PORT) return;
-    int8_t port_idx = _port_idx_by_address(gpio_port);
-    if (port_idx < 0) return;
+void gpio_control_reconfigure_pin(int portnum, int pinnum) {
+    if (portnum >= GPIO_CONGROL_NUM_PORTS) return;
+    if (pinnum >= GPIO_CONTROL_PINS_PER_PORT) return;
 
-    const gpio_control_pin_t *gpio_pin_cfg = &device_config_get()->gpio_control.ports[port_idx].pins[gpio_pin_num];
+    const gpio_control_pin_t *gpio_pin_cfg = &device_config_get()->gpio_control.ports[portnum].pins[pinnum];
     if (gpio_pin_cfg->dir == gpio_dir_unknown) {
         // pin is marked as non-usable
         return;
@@ -45,8 +50,11 @@ void gpio_control_reconfigure_pin(GPIO_TypeDef *gpio_port, uint8_t gpio_pin_num)
         return;
     }
     gpio_pin_t p;
-    _pin_control_cfg_prepare(&p, uart_pin, gpio_pin_cfg);
+    _pin_control_cfg_prepare(&p, portnum, pinnum);
     gpio_pin_init(&p);
+    if (p.dir == gpio_dir_output) {
+        gpio_pin_set(&p, gpio_pin_cfg->val);
+    }
 }
 
 gpio_pin_t *gpio_control_find_uart_pincfg(gpio_control_pin_t *gc_pin) {
@@ -55,14 +63,37 @@ gpio_pin_t *gpio_control_find_uart_pincfg(gpio_control_pin_t *gc_pin) {
     return &device_config_get()->cdc_config.port_config[gc_pin->uart_port].pins[gc_pin->uart_pin];
 }
 
+cdc_use_t gpio_control_pin_get_use(int portnum, int pinnum) {
+    if (portnum >= GPIO_CONGROL_NUM_PORTS) return cdc_use_unknown;
+    if (pinnum >= GPIO_CONTROL_PINS_PER_PORT) return cdc_use_unknown;
+
+    gpio_control_pin_t *gc_pin = &device_config_get()->gpio_control.ports[portnum].pins[pinnum];
+    if (gc_pin->dir == gpio_dir_unknown) return cdc_use_unknown;
+    gpio_pin_t *u_pin = gpio_control_find_uart_pincfg(gc_pin);
+    if (u_pin->func == gpio_func_unknown) return cdc_use_gpio;
+    return cdc_use_uart;
+}
+
 int gpio_control_read(int portnum, int pinnum) {
-    if (portnum >= GPIO_CONGROL_NUM_PORTS) return 0;
-    if (pinnum >= GPIO_CONTROL_PINS_PER_PORT) return 0;
+    if (portnum >= GPIO_CONGROL_NUM_PORTS) return -1;
+    if (pinnum >= GPIO_CONTROL_PINS_PER_PORT) return -1;
     gpio_control_pin_t *gc_pin = &device_config_get()->gpio_control.ports[portnum].pins[pinnum];
     gpio_pin_t *u_pin = gpio_control_find_uart_pincfg(gc_pin);
-    if (u_pin == NULL) return 0;
+    if (u_pin == NULL) return 0; // ???
 
     gpio_pin_t p;
-    _pin_control_cfg_prepare(&p, u_pin, gc_pin);
+    _pin_control_cfg_prepare(&p, portnum, pinnum);
     return gpio_pin_get(&p);
+}
+
+int gpio_control_write(int portnum, int pinnum, int val) {
+    if (portnum >= GPIO_CONGROL_NUM_PORTS) return -1;
+    if (pinnum >= GPIO_CONTROL_PINS_PER_PORT) return 1;
+
+    if (gpio_control_pin_get_use(portnum, pinnum) != cdc_use_gpio) return -1;
+
+    gpio_pin_t p;
+    _pin_control_cfg_prepare(&p, portnum, pinnum);
+    gpio_pin_set(&p, val);
+    return 0;
 }

--- a/gpio_control.c
+++ b/gpio_control.c
@@ -7,12 +7,6 @@
 #include "device_config.h"
 
 
-static inline int8_t _port_idx_by_address(GPIO_TypeDef *port) {
-    if (port == GPIOA) return 0;
-    if (port == GPIOB) return 1;
-    return -1;
-}
-
 static inline GPIO_TypeDef *_port_address_by_idx(int portnum) {
     if (portnum == 0) return GPIOA;
     if (portnum == 1) return GPIOB;

--- a/gpio_control.c
+++ b/gpio_control.c
@@ -1,0 +1,50 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 Kiril Zyapkov
+ */
+#include "gpio_control.h"
+#include "device_config.h"
+
+
+static inline int8_t _port_idx_by_address(GPIO_TypeDef *port) {
+    if (port == GPIOA) return 0;
+    if (port == GPIOB) return 1;
+    return -1;
+}
+
+static inline void _pin_control_cfg_prepare(gpio_pin_t *pin, const gpio_pin_t *uart_pin, const gpio_control_pin_t *gpio_pin) {
+    // memset(pin, 0, sizeof(*pin));
+
+    pin->port = uart_pin->port;
+    pin->pin = uart_pin->pin;
+    pin->dir = gpio_pin->dir;
+    pin->func = gpio_func_general;
+    // if (pin->dir == gpio_dir_output) {
+        pin->output = gpio_pin->output;
+    // } else { // output
+        pin->pull = gpio_pin->pull;
+    // }
+    pin->polarity = gpio_polarity_high;
+    pin->speed = gpio_speed_low;
+}
+
+void gpio_control_reconfigure_pin(GPIO_TypeDef *gpio_port, uint8_t gpio_pin_num) {
+    if (gpio_pin_num >= GPIO_CONTROL_PINS_PER_PORT) return;
+    int8_t port_idx = _port_idx_by_address(gpio_port);
+    if (port_idx < 0) return;
+
+    const gpio_control_pin_t *gpio_pin_cfg = &device_config_get()->gpio_control.ports[port_idx].pins[gpio_pin_num];
+    if (gpio_pin_cfg->dir == gpio_dir_unknown) {
+        // pin is marked as non-usable
+        return;
+    }
+    gpio_pin_t *uart_pin = &device_config_get()->cdc_config.port_config[gpio_pin_cfg->uart_port].pins[gpio_pin_cfg->uart_pin];
+    if (uart_pin->func != gpio_func_unknown) {
+        // pin is marked for use by uart machinery
+        return;
+    }
+    gpio_pin_t p;
+    _pin_control_cfg_prepare(&p, uart_pin, gpio_pin_cfg);
+    gpio_pin_init(&p);
+}

--- a/gpio_control.h
+++ b/gpio_control.h
@@ -1,0 +1,36 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 Kiril Zyapkov
+ */
+#ifndef GPIO_CONTROL_H
+#define GPIO_CONTROL_H
+
+#include <stdint.h>
+#include <stm32f1xx.h>
+#include "gpio.h"
+#include "usb_cdc.h"
+
+#define GPIO_CONTROL_PINS_PER_PORT 16
+
+typedef struct {
+    int             uart_port; // -1 if no uart port association
+    cdc_pin_t       uart_pin;
+    gpio_dir_t      dir; // unusable pins are marked with dir_unknown
+    gpio_pull_t     pull;
+    gpio_output_t   output;
+    gpio_polarity_t val;
+} __attribute__ ((packed)) gpio_control_pin_t;
+
+typedef struct {
+    gpio_control_pin_t pins[GPIO_CONTROL_PINS_PER_PORT];
+} __attribute__ ((packed)) gpio_control_port_t;
+
+typedef struct {
+    gpio_control_port_t ports[2];
+} __attribute__ ((packed)) gpio_control_config_t;
+
+
+void gpio_control_reconfigure_pin(GPIO_TypeDef *gpio_port, uint8_t gpio_pin);
+
+#endif

--- a/gpio_control.h
+++ b/gpio_control.h
@@ -20,7 +20,7 @@ typedef struct {
     gpio_dir_t      dir; // unusable pins are marked with dir_unknown
     gpio_pull_t     pull;
     gpio_output_t   output;
-    gpio_polarity_t val;
+    uint8_t         val;
 } __attribute__ ((packed)) gpio_control_pin_t;
 
 typedef struct {
@@ -32,9 +32,12 @@ typedef struct {
 } __attribute__ ((packed)) gpio_control_config_t;
 
 
-void gpio_control_reconfigure_pin(GPIO_TypeDef *gpio_port, uint8_t gpio_pin);
+void gpio_control_reconfigure_pin(int portnum, int pinnum);
 gpio_pin_t *gpio_control_find_uart_pincfg(gpio_control_pin_t *gc_pin);
 
+cdc_use_t gpio_control_pin_get_use(int portnum, int pinnum);
+
 int gpio_control_read(int portnum, int pinnum);
+int gpio_control_write(int portnum, int pinnum, int val);
 
 #endif

--- a/gpio_control.h
+++ b/gpio_control.h
@@ -12,6 +12,7 @@
 #include "usb_cdc.h"
 
 #define GPIO_CONTROL_PINS_PER_PORT 16
+#define GPIO_CONGROL_NUM_PORTS 2
 
 typedef struct {
     int             uart_port; // -1 if no uart port association
@@ -32,5 +33,8 @@ typedef struct {
 
 
 void gpio_control_reconfigure_pin(GPIO_TypeDef *gpio_port, uint8_t gpio_pin);
+gpio_pin_t *gpio_control_find_uart_pincfg(gpio_control_pin_t *gc_pin);
+
+int gpio_control_read(int portnum, int pinnum);
 
 #endif

--- a/usb_cdc.h
+++ b/usb_cdc.h
@@ -191,6 +191,14 @@ typedef enum {
 } __attribute__ ((packed)) cdc_pin_t;
 
 
+typedef enum {
+    cdc_use_uart,
+    cdc_use_gpio,
+    cdc_use_unknown,
+    cdc_use_last = cdc_use_unknown,
+} __attribute__ ((packed)) cdc_use_t;
+
+
 /* Configuration Changed Hooks */
 
 void usb_cdc_reconfigure_port_pin(int port, cdc_pin_t pin);

--- a/usb_io.c
+++ b/usb_io.c
@@ -1,6 +1,6 @@
 /*
- * MIT License 
- * 
+ * MIT License
+ *
  * Copyright (c) 2020 Kirill Kotyagin
  */
 
@@ -243,7 +243,7 @@ void usb_poll() {
         status_led_set(1);
     } else if (istr & USB_ISTR_RESET) {
         USB->ISTR = (uint16_t)(~USB_ISTR_RESET);
-        usb_device_handle_reset();   
+        usb_device_handle_reset();
     } else if (istr & USB_ISTR_SUSP) {
         USB->ISTR = (uint16_t)(~USB_ISTR_SUSP);
         USB->CNTR |= USB_CNTR_FSUSP;


### PR DESCRIPTION
This is a proposal for enhancing the capabilities of the serial monster by adding arbitrary GPIO control.

Having serial ports with all the bells and whistles is awesome. However, sometimes not all 3 ports are required, or not all signals for a given port are required. It then makes sense to enable those pins to be controlled with console commands. This enables many use cases where slow GPIO access is enough to sense the state of the attached system or operate attached peripherals.

This PR implements a proof-of-concept of the above proposal. It tries to follow the original coding style, but does take many shortcuts and does add `stdio` to the linked libraries, bloating the size of the firmware by a few KB. The envisioned use case is for the first port to always be a control/config console, and the second and third UARTs to be available for use as either serial ports or their pins to be used as generic inputs or outputs. The control console can be scripted (with expect or expect-like tool) or operated manually by typing in commands.

By default, the monster behaves just like before -- all pins are associated to serial ports an controlled by the CDC-ACM machinery. If the `use` parameter of a signal is set to `gpio` it is detached from said machinery and is available as IO.

A sample command session, annotated:

```
# switch uart1 dcd signal to be used as gpio (PB15)
>uart 1 dcd use gpio
# when switched to GPIO use, pins are high-Z inputs by default
# read the state of all GPIO-configured signals:
>gpio read
B15:1 
# switch uart3 cts to be used as gpio (PB13)
>uart 3 cts use gpio
>gpio read
B13:1 B15:1 
# configure PB13 as output, set to low
>gpio config b13 dir out val 0
B13: output pp floating 0
# configure PB15 with pulldown
>gpio config b15 pull down
B15: input pp down 0
# read a single gpio
>gpio read b15
B15:0 
# or all gpios
>gpio read
B13:0 B15:0 
>gpio write b13 1
>gpio read
B13:1 B15:0 
```

While quite crude, the implementation is functional enough. If deemed upstreamable I'll try to polish it, probably add a few more features to facilitate programatic usage.