### PR TITLE
Move CDC polling out of main

### DIFF
--- a/main.c
+++ b/main.c
@@ -10,8 +10,6 @@
 #include "status_led.h"
 #include "device_config.h"
 #include "usb.h"
-#include "usb_cdc.h"
-
 
 int main() {
     system_clock_init();

--- a/main.c
+++ b/main.c
@@ -21,6 +21,5 @@ int main() {
     usb_init();
     while (1) {
         usb_poll();
-        usb_cdc_poll();
     }
 }

--- a/usb_core.c
+++ b/usb_core.c
@@ -54,6 +54,10 @@ void usb_device_handle_frame() {
     usb_cdc_frame();
 }
 
+void usb_device_poll() {
+    usb_cdc_poll();
+}
+
 /* Device Descriptor Requests Handling */
 
 usb_status_t usb_control_endpoint_process_get_descriptor(usb_setup_t *setup,

--- a/usb_core.h
+++ b/usb_core.h
@@ -47,5 +47,6 @@ void usb_device_handle_configured();
 void usb_device_handle_suspend();
 void usb_device_handle_wakeup();
 void usb_device_handle_frame();
+void usb_device_poll();
 
 #endif /* USB_CORE_H */

--- a/usb_io.c
+++ b/usb_io.c
@@ -260,4 +260,5 @@ void usb_poll() {
         }
         usb_device_handle_frame();
     }
+    usb_device_poll();
 }


### PR DESCRIPTION
Introduce a device level polling function, so that CDC and other subsystems polling (if any) can live there.